### PR TITLE
Improvement: Grapheme cluster counting for flag emojis

### DIFF
--- a/lib/src/main/kotlin/com/github/hiking93/graphemesplitterlite/GraphemeSplitter.kt
+++ b/lib/src/main/kotlin/com/github/hiking93/graphemesplitterlite/GraphemeSplitter.kt
@@ -61,6 +61,7 @@ class GraphemeSplitter {
             ) {
                 if (regionalIndicatorPairEndIndex < index) {
                     regionalIndicatorPairEndIndex = index + Character.toChars(codePointAtIndex).size
+                    breaks += index
                     continue
                 }
             }

--- a/lib/src/test/kotlin/com/github/hiking93/graphemesplitterlite/GraphemeTest.kt
+++ b/lib/src/test/kotlin/com/github/hiking93/graphemesplitterlite/GraphemeTest.kt
@@ -96,6 +96,10 @@ class GraphemeTest {
             listOf("\uD83C\uDDEF\uD83C\uDDF5", "\uD83C\uDDEF"),
             GraphemeSplitter().split("\uD83C\uDDEF\uD83C\uDDF5\uD83C\uDDEF")
         )
+        Assertions.assertEquals(
+            listOf("\uD83C\uDDEF\uD83C\uDDF5", "\uD83C\uDDEF\uD83C\uDDF5"),
+            GraphemeSplitter().split("\uD83C\uDDEF\uD83C\uDDF5\uD83C\uDDEF\uD83C\uDDF5")
+        )
     }
 
     @Test


### PR DESCRIPTION
Addresses an issue where flag emojis (composed of two regional indicator symbols) were incorrectly counted as a single grapheme cluster. The code now correctly identifies and counts each regional indicator symbol, resulting in accurate counts for flag emojis like 🇯🇵🇯🇵🇯🇵 (now counted as 3, previously 1).